### PR TITLE
Adds simple support for HTTP OPTIONS requests

### DIFF
--- a/src/conf/autoload.php
+++ b/src/conf/autoload.php
@@ -34,6 +34,7 @@ $autoloadClasses = array(
 		'Proxy'                     => '/models/Proxy.php',
 		'Validateable'              => '/models/Validateable.php',
 		'ValidateableModelProxy'    => '/models/ValidateableModelProxy.php',
+		'EmptyResponse'              => '/response/EmptyResponse.php',
 		'FileResponse'              => '/response/FileResponse.php',
 		'JsonResponse'              => '/response/JsonResponse.php',
 		'NotFoundResponse'          => '/response/NotFoundResponse.php',

--- a/src/core/ActionMapping.php
+++ b/src/core/ActionMapping.php
@@ -3,7 +3,7 @@
  * This class encapsulates information about the mapping to an action.
  * 
  * The mapping to an action consists of the name of the action class and the action method
- * within that class.
+ * within that class or a callable function.
  */
 class ActionMapping {
 	/**
@@ -30,7 +30,7 @@ class ActionMapping {
 	 * callable.
 	 *
 	 * @param string $actionPath	Full path to the action class.
-	 * @param string $actionMethod	Name of the action method in the action class.
+	 * @param string $actionMethod	Name of the action method in the action class, or an actual callable.
 	 */
 	public function __construct ($actionPath, $actionMethod) {
 		require($actionPath);
@@ -38,7 +38,7 @@ class ActionMapping {
 		$this->actionClass	= basename($actionPath, '.php');
 		$this->actionMethod	= $actionMethod;
 
-		if (!method_exists($this->actionClass, $actionMethod)) {
+		if (!is_callable($actionMethod) && !method_exists($this->actionClass, $actionMethod)) {
 			throw new Exception("No callable action method $actionMethod found in $actionPath");
 		}
 	}

--- a/src/core/DefaultActionMapper.php
+++ b/src/core/DefaultActionMapper.php
@@ -76,7 +76,9 @@ class DefaultActionMapper {
 	}
 
 	/**
-	 * Maps the request method to an action method. We currently only support GET and POST.
+	 * Maps the request method to an action method. We currently only support GET and POST,
+	 * and a very simple OPTIONS request that simply responds with GET and POST being allowed
+	 * even if the actual action might not support both.
 	 *
 	 * @param string $method	Request method.
 	 * @return string			Action method to use.
@@ -89,9 +91,15 @@ class DefaultActionMapper {
 		else if ($method == 'POST') {
 			return 'doPost';
 		}
-		else {
-			throw new Exception("Request method $method is not supported");
+		else if ($method == 'OPTIONS') {
+			return function ($request) {
+				return new EmptyResponse(array('Allow' => 'GET, POST'));
+			};
 		}
+
+		return function ($request) {
+			return new EmptyResponse(array('Allow' => 'GET, POST'), 405);
+		};
 	}
 
 	/**

--- a/src/core/Dispatcher.php
+++ b/src/core/Dispatcher.php
@@ -100,7 +100,15 @@ class Dispatcher {
 				return $result;
 			}
 		}
-		return $this->action->{$this->actionMethod}($this->getRequest());
+
+		if (is_callable($this->actionMethod)) {
+			$fn = $this->actionMethod;
+		}
+		else {
+			$fn = $this->action->{$this->actionMethod};
+		}
+
+		return $fn($this->getRequest());
 	}
 
 	public function getRequest () {

--- a/src/response/EmptyResponse.php
+++ b/src/response/EmptyResponse.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * A simple response without a content body, simplifying setting headers directly
+ * in the constructor.
+ */
+class EmptyResponse extends Response {
+
+	/**
+	 * Initializes the empty response, setting any headers directly and optionally overriding
+	 * the HTTP status code if needed.
+	 */
+	public function __construct ($headers = array(), $status = 200) {
+		$this->status = $status;
+
+		if (!empty($headers)) {
+			foreach ($headers as $key => $value) {
+				$this->setHeader($key, $value);
+			}
+		}
+	}
+
+	/**
+	 * Overrides the default render, only sending headers in the response and no body content.
+	 */
+	public function render ($request) {
+		$this->sendHeaders();
+	}
+}


### PR DESCRIPTION
Lets the default action mapper know about the HTTP OPTIONS method, which currently simply responds with an Allow header saying both GET and POST is supported for all requests. A future more correct implementation might introspect the mapped action class for which methods it actually responds too.

This lets Kolibri handle requests from Microsoft Service Discovery and similar robots which sends OPTIONS requests to map out which HTTP methods are supported on URLs.
