### PR TITLE
Add phone validator

### DIFF
--- a/src/conf/validation.php
+++ b/src/conf/validation.php
@@ -17,6 +17,7 @@ define('IS_DATETIME', 1024);
 define('IS_HEX', 2048);
 define('IS_FILE', 4096);
 define('IN_DB', 8192);
+define('IS_PHONE', 16384);
 
 /*
  * Maps validation rules to validator classes used to perform the validation.
@@ -35,7 +36,8 @@ $validators = array(
 	IS_DATETIME	=> 'DateTimeValidator',
 	IS_HEX      => 'HexValidator',
 	IS_FILE     => 'FileValidator',
-	IN_DB       => 'InDbValidator'
+	IN_DB       => 'InDbValidator',
+	IS_PHONE    => 'PhoneValidator',
 );
 
 /*
@@ -63,6 +65,7 @@ $validationMessages = array(
 	'file_ini_size' => '%s overstiger maksimal tillatt filstørrelse.',
 	'file_partial'  => '%s ble ikke fullestendig opplastet. Vennligst prøv igjen.',
 	'type'          => '%s må være en av følgende filtyper: %s',
-	'in_db'         => '%s «%s» eksisterer ikke.'
+	'in_db'         => '%s «%s» eksisterer ikke.',
+	'phone'         => '%s må være et gyldig telefonnummer.',
 );
 ?>

--- a/src/validation/PhoneValidator.php
+++ b/src/validation/PhoneValidator.php
@@ -1,0 +1,42 @@
+<?php
+class PhoneValidator {
+	private $model;
+
+	public function __construct ($model) {
+		$this->model = $model;
+	}
+
+	public function validate ($property, $rules) {
+		try {
+			$phoneNumberUtil = \libphonenumber\PhoneNumberUtil::getInstance();
+			$region = !empty($rules['region']) ? $rules['region'] : null;
+			$phoneNumber = $phoneNumberUtil->parse($this->model->$property, $region);
+
+			if (!empty($rules['type'])) {
+				$type = $this->mapType($rules['type']);
+				$result = $phoneNumberUtil->isPossibleNumberForTypeWithReason(
+					$phoneNumber, $type
+				) === \libphonenumber\ValidationResult::IS_POSSIBLE;
+			}
+			else {
+				$result = true;
+			}
+		}
+		catch (\libphonenumber\NumberParseException $e) {
+			$result = false;
+		}
+
+		return $result === true ? true : array('phone' => $rules['name']);
+	}
+
+	private function mapType ($type) {
+		switch ($type) {
+			case 'mobile':
+				return \libphonenumber\PhoneNumberType::MOBILE;
+			case 'landline':
+				return \libphonenumber\PhoneNumberType::FIXED_LINE;
+			default:
+				return \libphonenumber\PhoneNumberType::UNKNOWN;
+		}
+	}
+}


### PR DESCRIPTION
The phone validator uses the PHP port of Google's `libphonenumber`. It supports defining the region for validating numbers within and optional type to attempt validating. Region is not required if phone numbers contain the country code, but must otherwise be provided. Type can not be guaranteed verified. Currently only `mobile` and `landline` are valid types to specify.