### PR TITLE
Don't require a phone number in validator

### DIFF
--- a/src/validation/PhoneValidator.php
+++ b/src/validation/PhoneValidator.php
@@ -7,6 +7,10 @@ class PhoneValidator {
 	}
 
 	public function validate ($property, $rules) {
+		if (empty($this->model->$property)) {
+			return true;
+		}
+
 		try {
 			$phoneNumberUtil = \libphonenumber\PhoneNumberUtil::getInstance();
 			$region = !empty($rules['region']) ? $rules['region'] : null;


### PR DESCRIPTION
The phone number validator shouldn't require a value, rather the validator to check for existance of a value should be used if that's a requirement too. This simply bails out of phone number validation if the property value is empty.