### PR TITLE
Improve escaping of `COPY FROM` data

### DIFF
--- a/src/database/PostgreSqlConnection.php
+++ b/src/database/PostgreSqlConnection.php
@@ -258,9 +258,11 @@ class PostgreSqlConnection extends DatabaseConnection {
 		if ($value === null) {
 			return $nullValue;
 		}
+
 		if (is_bool($value)) {
 			return ($value ? 'true' : 'false');
 		}
+
 		if (is_array($value)) {
 			$innerDelims = array_fill(0, count($value), $delimiterChar);
 			$innerNulls = array_fill(0, count($value), $nullValue);
@@ -270,13 +272,14 @@ class PostgreSqlConnection extends DatabaseConnection {
 					array($this, 'escapeCopyValue'), $value, $innerDelims, $innerNulls)
 			) . '}';
 		}
-		if (get_magic_quotes_gpc()) {
-			$value = stripslashes($value);
-		}
+
 		return strtr($value, array(
-			'}' => '\\\}',
-			'{' => '\\\{',
-			'"' => '\\\"',
+			"\n" => '\\\n',
+			"\r" => '\\\r',
+			'}' => '\\}',
+			'{' => '\\{',
+			'"' => '\\"',
+			'\\' => '\\\\',
 			$delimiterChar => '\\'.$delimiterChar));
 	}
 


### PR DESCRIPTION
Fixes correct escaping of some existing characters we handled, and adds support for escaping the backslash, newline and carriage return characters properly in `COPY FROM` data. The PostgreSQL documentation of the `COPY FROM` command states that backslash and delimiter character must be escaped, in addition to newline and carriage return.

In addition the support for handling PHPs magic quotes feature is removed, as this feature was removed from PHP 5.4, and the `get_magic_quotes_gpc` function would just always return `false`.