### PR TITLE
Throw exception when `COPY FROM` fails

### DIFF
--- a/src/database/PostgreSqlConnection.php
+++ b/src/database/PostgreSqlConnection.php
@@ -215,7 +215,18 @@ class PostgreSqlConnection extends DatabaseConnection {
 
 			$rows = $escapedRows;
 		}
-		return pg_copy_from($this->connection, $table, $rows, $delimiter, $null);
+
+		$result = pg_copy_from($this->connection, $table, $rows, $delimiter, $null);
+
+		if (!$result) {
+			$lastError = pg_last_error();
+			$this->rollback();
+
+			$query = "COPY $table FROM \n" . implode("\n", $rows);
+			throw new SqlException($lastError, $query);
+		}
+
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
This adds better error handling like we have for normal queries. If the `COPY FROM` query fails we now fetch the PostgreSQL error message and throw an `SqlException` with the error and the full query attempted.