### PR TITLE
Make email validation a bit stricter again

### DIFF
--- a/src/validation/EmailValidator.php
+++ b/src/validation/EmailValidator.php
@@ -8,7 +8,7 @@ class EmailValidator {
 
 	public function validate ($property, $rules) {
 		if (!empty($this->model->$property)) {
-			if (preg_match('/^\A[^\s@]+@[^\s.@][^\s@]*\.[^\s@]+$/ui', $this->model->$property) != 1) {
+			if (preg_match('/^\A[^\s"(),:;<>\[\]\\\@]+@[^\s.@][^\s@]*\.[^\s@]+$/ui', $this->model->$property) != 1) {
 				return array('email' => $rules['name']);
 			}
 		}


### PR DESCRIPTION
This expands the email validation somewhat, adding characters that can only be used within a quoted part of an email address to the illegal characters in the local part of the address. These are characters like backslash, square brackets, parenthesis etc. which in general nobody use or should use.