### PR TITLE
Cast unique validator value to text

### DIFF
--- a/src/validation/UniqueValidator.php
+++ b/src/validation/UniqueValidator.php
@@ -61,7 +61,7 @@ class UniqueValidator {
 			}
 
 			$query = "SELECT 1 FROM $relation WHERE "
-				. ($sensitive ? "$property = $valuePlaceholder " : "lower($property) = lower($valuePlaceholder) ")
+				. ($sensitive ? "$property = $valuePlaceholder " : "lower($property) = lower($valuePlaceholder::text) ")
 				. $whereString;
 			if ($db->getColumn($query, $whereValues)) {
 				// The query found a row -- it's not unique


### PR DESCRIPTION
If passed in as an integer the SQL will fail, but when casting before
lowering we make sure it does work.