### PR TITLE
Automatically reconnect PostgreSQL database connections

### DIFF
--- a/src/database/PostgreSqlConnection.php
+++ b/src/database/PostgreSqlConnection.php
@@ -298,7 +298,7 @@ class PostgreSqlConnection extends DatabaseConnection {
 	 * Prepares the connection before a query is sent.
 	 */
 	private function prepareConnection () {
-		if (!$this->connection) {
+		if (!$this->connection || pg_ping($this->connection) === false) {
 			$this->connect();
 		}
 


### PR DESCRIPTION
Before issuing a query we always make sure a database connection is set up. But if this connection has become broken the query will fail anyhow. This adds a connection status check as well before any query, and if the connection status is not OK we simply reconnect.